### PR TITLE
Fix calls to management canister

### DIFF
--- a/request.go
+++ b/request.go
@@ -110,7 +110,9 @@ func NewRequestID(req Request) RequestID {
 		typeHash := sha256.Sum256([]byte(req.Type))
 		hashes = append(hashes, append(typeKey[:], typeHash[:]...))
 	}
-	if len(req.CanisterID.Raw) != 0 {
+	// NOTE: the canister ID may be the empty slice. The empty slice doesn't mean it's not
+	// set, it means it's the management canister (aaaaa-aa).
+	if req.CanisterID.Raw != nil {
 		canisterIDHash := sha256.Sum256(req.CanisterID.Raw)
 		hashes = append(hashes, append(canisterIDKey[:], canisterIDHash[:]...))
 	}


### PR DESCRIPTION
This fixes an issue in the RequestID computation where an empty slice canister ID would be considered as "canister_id not set". This was not quite correct, because the management canister ID is the empty slice (encoded as "aaaaa-aa").

This changes the empty check for a `nil` check instead. Usages of the effective canister ID vs. canister ID are also clarified.

This also changes the way the logger prints the request ID to use a hex representation, which is easier to read & convert than the byte characters.