### PR TITLE
Add nonce to requests

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"reflect"
 	"time"
@@ -132,6 +133,7 @@ func (a Agent) Call(canisterID principal.Principal, methodName string, args []an
 		MethodName:    methodName,
 		Arguments:     rawArgs,
 		IngressExpiry: a.expiryDate(),
+		Nonce:         newNonce(),
 	})
 	if err != nil {
 		return err
@@ -224,6 +226,12 @@ func (a Agent) GetRootKey() []byte {
 	return a.rootKey
 }
 
+func newNonce() []byte {
+	nonce := make([]byte, 10)
+	rand.Read(nonce)
+	return nonce
+}
+
 func (a Agent) Query(canisterID principal.Principal, methodName string, args []any, values []any) error {
 	rawArgs, err := idl.Marshal(args)
 	if err != nil {
@@ -240,6 +248,7 @@ func (a Agent) Query(canisterID principal.Principal, methodName string, args []a
 		MethodName:    methodName,
 		Arguments:     rawArgs,
 		IngressExpiry: a.expiryDate(),
+		Nonce:         newNonce(),
 	})
 	if err != nil {
 		return err

--- a/agent.go
+++ b/agent.go
@@ -227,6 +227,8 @@ func (a Agent) GetRootKey() []byte {
 }
 
 func newNonce() []byte {
+	/* Read 10 bytes of random data, which is smaller than the max allowed by the IC (32 bytes)
+	 * and should still be enough from a practical point of view. */
 	nonce := make([]byte, 10)
 	rand.Read(nonce)
 	return nonce


### PR DESCRIPTION
This adds nonce to query & update calls to differentiate calls sent during e.g. the same second.