### PR TITLE
Nit: Update package name to represent crust instead of cmotoko

### DIFF
--- a/common/crust/result.go
+++ b/common/crust/result.go
@@ -1,4 +1,4 @@
-package cmotoko
+package crust
 
 // Result is a generic type that represents either success (Ok) or failure (Err).
 // It is used as the return type of functions which may fail.


### PR DESCRIPTION
Fixes incorrect package name
